### PR TITLE
Fix Download Links

### DIFF
--- a/de/basic/administrator/README.md
+++ b/de/basic/administrator/README.md
@@ -17,7 +17,7 @@ parent: Deutsch
 - 64-Bit (Windows 10+, Windows Server 2016+)
 
 ## Installation
-1. Laden Sie die Version für Ihre Plattform von <https://learn2rag.de/download> herunter.
+1. Laden Sie die Version für Ihre Plattform von <https://learn2rag.de/downloads> herunter.
 2. Extrahieren Sie das Archiv.
 3. Führen Sie die Datei namens `start` aus. 
 

--- a/en/basic/administrator/index.md
+++ b/en/basic/administrator/index.md
@@ -18,7 +18,7 @@ parent: English
 - 64-bit (Windows 10+, Windows Server 2016+)
 
 ## Obtaining, installation and starting
-Download the release for your platform at <https://learn2rag.de/download>.
+Download the release for your platform at <https://learn2rag.de/downloads>.
 Extract the archive.
 ```sh
 unzip learn2rag-linux.zip


### PR DESCRIPTION
Links to the Learn2RAG Download were missing an `s` at the end of the URL